### PR TITLE
:bug: Fix fpnew_cast_multi signedness bug

### DIFF
--- a/src/fpnew_cast_multi.sv
+++ b/src/fpnew_cast_multi.sv
@@ -441,7 +441,7 @@ module fpnew_cast_multi #(
     // Handle FP over-/underflows
     end else begin
       // Overflow or infinities (for proper rounding)
-      if ((destination_exp_q >= 2**fpnew_pkg::exp_bits(dst_fmt_q2)-1) ||
+      if ((destination_exp_q >= signed'(2**fpnew_pkg::exp_bits(dst_fmt_q2)-1)) ||
           (~src_is_int_q && info_q.is_inf)) begin
         final_exp       = unsigned'(2**fpnew_pkg::exp_bits(dst_fmt_q2)-2); // largest normal value
         preshift_mant   = '1;                           // largest normal value and RS bits set


### PR DESCRIPTION
There was a signedness bug in fpnew_cast_multi that causes VCS to behave
incorrectly when converting a small double into float. This fixes #24.