### PR TITLE
Minor Warning Fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions of the IP in the same major relase are "pin-compatible" with each other
 ### Added
 ### Changed
 ### Fixed
+- Fix potentially uncovered case item in `fpnew_pkg`
 - Undriven unused portions of signals in multi-format slices
 - Undriven portions of the result for non-divisible unit width & format width in multi-format slices
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ Versions of the IP in the same major relase are "pin-compatible" with each other
 ### Added
 ### Changed
 ### Fixed
+- Fix undriven signals for inactive case in `fpnew_fma_multi`
 - Fix potentially uncovered case item in `fpnew_pkg`
 - Undriven unused portions of signals in multi-format slices
 - Undriven portions of the result for non-divisible unit width & format width in multi-format slices

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -336,6 +336,8 @@ module fpnew_fma_multi #(
       end
     end else begin : inactive_format
       assign fmt_special_result[fmt] = '{default: fpnew_pkg::DONT_CARE};
+      assign fmt_special_status[fmt] = '0;
+      assign fmt_result_is_special[fmt] = 1'b0;
     end
   end
 

--- a/src/fpnew_pkg.sv
+++ b/src/fpnew_pkg.sv
@@ -89,6 +89,14 @@ package fpnew_pkg;
       INT16: return 16;
       INT32: return 32;
       INT64: return 64;
+      default: begin
+        // pragma translate_off
+        $fatal(1, "Invalid INT format supplied");
+        // pragma translate_on
+        // just return any integer to avoid any latches
+        // hopefully this error is caught by simulation
+        return INT8;
+      end
     endcase
   endfunction
 


### PR DESCRIPTION
Two extremely minor warning fixes backported from Snitch. As far as I remember they fix some warnings in tools we don't use very often.