### PR TITLE
Bump common cells

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -3,7 +3,7 @@ package:
   authors: ["Stefan Mach <smach@iis.ee.ethz.ch>"]
 
 dependencies:
-  common_cells: {git: "https://github.com/pulp-platform/common_cells.git",         version: 1.13.1}
+  common_cells: {git: "https://github.com/pulp-platform/common_cells.git",         version: 1.20.0}
   fpu_div_sqrt_mvp: {git: "https://github.com/pulp-platform/fpu_div_sqrt_mvp.git", version: 1.0.4}
 
 sources:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ Versions of the IP in the same major relase are "pin-compatible" with each other
 ### Added
 ### Changed
 ### Fixed
-
+- [common_cells] Bump to fix compilation order
 
 ## [0.6.4] - 2020-10-05
 

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,7 +19,7 @@
 #
 
 common_cells:
-  commit: v1.13.1
+  commit: v1.20.0
   domain: [soc, cluster]
 
 fpu_div_sqrt_mvp:


### PR DESCRIPTION
Update `common_cells` version. The `common_cells` referred to in the `src_files.yml` has a problematic compile order baked in.