### PR TITLE
Bump common_cells version

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -3,7 +3,7 @@ package:
   authors: ["Stefan Mach <smach@iis.ee.ethz.ch>"]
 
 dependencies:
-  common_cells: {git: "https://github.com/pulp-platform/common_cells.git",         version: 1.20.0}
+  common_cells: {git: "https://github.com/pulp-platform/common_cells.git",         version: 1.21.0}
   fpu_div_sqrt_mvp: {git: "https://github.com/pulp-platform/fpu_div_sqrt_mvp.git", version: 1.0.4}
 
 sources:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,8 +12,9 @@ Versions of the IP in the same major relase are "pin-compatible" with each other
 
 ### Added
 ### Changed
+- [common_cells] Bump common cells version
+
 ### Fixed
-- [common_cells] Bump to fix compilation order
 
 
 ## [0.6.5] - 2020-11-06

--- a/ips_list.yml
+++ b/ips_list.yml
@@ -19,7 +19,7 @@
 #
 
 common_cells:
-  commit: v1.20.0
+  commit: v1.21.0
   domain: [soc, cluster]
 
 fpu_div_sqrt_mvp:


### PR DESCRIPTION
Required for conflict free backwards compatibility with IPApprox Flow