### PR TITLE
Add CITATION.cff for GitHub's new cite repository feature

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+@article{mach2020fpnew,
+  title={Fpnew: An open-source multiformat floating-point unit architecture for energy-proportional transprecision computing},
+  author={Mach, Stefan and Schuiki, Fabian and Zaruba, Florian and Benini, Luca},
+  journal={IEEE Transactions on Very Large Scale Integration (VLSI) Systems},
+  volume={29},
+  number={4},
+  pages={774--787},
+  year={2020},
+  publisher={IEEE}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ Versions of the IP in the same major relase are "pin-compatible" with each other
 ## [Unreleased]
 
 ### Added
+- Citation file `CITATION.cff`
 ### Changed
 ### Fixed
 


### PR DESCRIPTION
Use GitHub's new cite repository feature for easy citations with a CITATION.cff file in the root of the repository.