### PR TITLE
Align package name with dependency reference name

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -1,5 +1,5 @@
 package:
-  name: FPnew
+  name: fpnew
   authors: ["Stefan Mach <smach@iis.ee.ethz.ch>"]
 
 dependencies:


### PR DESCRIPTION
Bender has the issue, that most of the time it ignores the name stated in the
bender.yml and uses the name used in dependent packages (e.g. riscv core
package). All other repos refer to this package as "fpnew" although it is
actually called "FPnew". This can cause issues since bender does not
realize that there are clashes between identical packages (according to their
package name) if the parent packages refer to them under different names. This
can cause a whole nightmare of synthesis issues if incompatible versions are
involuntarily combined that way.