### PR TITLE
Allow for INT widths different from FP widths

### DIFF
--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -167,9 +167,9 @@ or set Features.FpFmtMask to support only FP32");
     // Cast-specific parameters
     localparam fpnew_pkg::fmt_logic_t CONV_FORMATS =
         fpnew_pkg::get_conv_lane_formats(Width, FpFmtConfig, LANE);
-    localparam fpnew_pkg::ifmt_logic_t CONV_INT_FORMATS =
-        fpnew_pkg::get_conv_lane_int_formats(Width, FpFmtConfig, IntFmtConfig, LANE);
-    localparam int unsigned CONV_WIDTH = fpnew_pkg::max_fp_width(CONV_FORMATS);
+    localparam fpnew_pkg::ifmt_logic_t CONV_INT_FORMATS = IntFmtConfig;
+    localparam int unsigned CONV_WIDTH = 
+        fpnew_pkg::maximum(fpnew_pkg::max_fp_width(CONV_FORMATS), fpnew_pkg::max_int_width(CONV_INT_FORMATS));
 
     // Lane parameters from Opgroup
     localparam fpnew_pkg::fmt_logic_t LANE_FORMATS = (OpGroup == fpnew_pkg::CONV)
@@ -409,7 +409,7 @@ or set Features.FpFmtMask to support only FP32");
       for (genvar ifmt = 0; ifmt < NUM_INT_FORMATS; ifmt++) begin : pack_int_result
         // Set up some constants
         localparam int unsigned INT_WIDTH = fpnew_pkg::int_width(fpnew_pkg::int_format_e'(ifmt));
-        if (ACTIVE_INT_FORMATS[ifmt]) begin
+        if (CONV_INT_FORMATS[ifmt]) begin
           assign ifmt_slice_result[ifmt][(LANE+1)*INT_WIDTH-1:LANE*INT_WIDTH] =
             local_result[INT_WIDTH-1:0];
         end else if ((LANE+1)*INT_WIDTH <= Width) begin


### PR DESCRIPTION
Allows e.g. an FP16-only FPU to support INT8 and INT32:
``` 
localparam fpu_features_t CUSTOM = '{
    Width:         32,
    EnableVectors: 1'b0,
    EnableNanBox:  1'b1,
    FpFmtMask:     5'b00100,
    IntFmtMask:    4'b1110
  };
```