### PR TITLE
🩹 Fix result of not equal compare w signaling NaNs

### DIFF
--- a/src/fpnew_noncomp.sv
+++ b/src/fpnew_noncomp.sv
@@ -260,7 +260,7 @@ module fpnew_noncomp #(
     cmp_result = '0; // false
     cmp_status = '0; // no flags
 
-    // Signalling NaNs always compare as false and are illegal
+    // Signalling NaNs always compare as false (except for "not equal" compares) and are illegal
     if (signalling_nan) begin
       cmp_status.NV = 1'b1; // invalid operation
       cmp_result    = inp_pipe_rnd_mode_q[NUM_INP_REGS] == fpnew_pkg::RDN && inp_pipe_op_mod_q[NUM_INP_REGS];

--- a/src/fpnew_noncomp.sv
+++ b/src/fpnew_noncomp.sv
@@ -261,9 +261,11 @@ module fpnew_noncomp #(
     cmp_status = '0; // no flags
 
     // Signalling NaNs always compare as false and are illegal
-    if (signalling_nan) cmp_status.NV = 1'b1; // invalid operation
+    if (signalling_nan) begin
+      cmp_status.NV = 1'b1; // invalid operation
+      cmp_result    = inp_pipe_rnd_mode_q[NUM_INP_REGS] == fpnew_pkg::RDN && inp_pipe_op_mod_q[NUM_INP_REGS];
     // Otherwise do comparisons
-    else begin
+    end else begin
       unique case (inp_pipe_rnd_mode_q[NUM_INP_REGS])
         fpnew_pkg::RNE: begin // Less than or equal
           if (any_operand_nan) cmp_status.NV = 1'b1; // Signalling comparison: NaNs are invalid


### PR DESCRIPTION
Currently the NONCOMP block sets the result bit when either operand of a "not equal" comparison is a quiet NaN but not for signaling NaNs. In order to treat quiet and signaling NaNs consistently and to be in line with the RISC-V spec, this PR modifies the NONCOMP compare logic to set the result bit when either of the operands of a "not equal" compare is a signaling NaN as well.

Fixes #115.