### PR TITLE
🐛 Fix handling of new symmetric add operation

### DIFF
--- a/src/fpnew_fma.sv
+++ b/src/fpnew_fma.sv
@@ -196,7 +196,8 @@ module fpnew_fma #(
     unique case (inp_pipe_op_q[NUM_INP_REGS])
       fpnew_pkg::FMADD:  ; // do nothing
       fpnew_pkg::FNMSUB: operand_a.sign = ~operand_a.sign; // invert sign of product
-      fpnew_pkg::ADD: begin // Set multiplicand to +1
+      fpnew_pkg::ADD,
+      fpnew_pkg::ADDS: begin // Set multiplicand to +1
         operand_a = '{sign: 1'b0, exponent: BIAS, mantissa: '0};
         info_a    = '{is_normal: 1'b1, is_boxed: 1'b1, default: 1'b0}; //normal, boxed value.
       end

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -245,7 +245,8 @@ module fpnew_fma_multi #(
     unique case (inp_pipe_op_q[NUM_INP_REGS])
       fpnew_pkg::FMADD:  ; // do nothing
       fpnew_pkg::FNMSUB: operand_a.sign = ~operand_a.sign; // invert sign of product
-      fpnew_pkg::ADD: begin // Set multiplicand to +1
+      fpnew_pkg::ADD,
+      fpnew_pkg::ADDS: begin // Set multiplicand to +1
         operand_a = '{sign: 1'b0, exponent: fpnew_pkg::bias(src_fmt_q), mantissa: '0};
         info_a    = '{is_normal: 1'b1, is_boxed: 1'b1, default: 1'b0}; //normal, boxed value.
       end

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -376,7 +376,9 @@ module fpnew_fma_multi #(
 
   // Calculate internal exponents from encoded values. Real exponents are (ex = Ex - bias + 1 - nx)
   // with Ex the encoded exponent and nx the implicit bit. Internal exponents are biased to dst fmt.
-  assign exponent_addend = signed'(exponent_c + $signed({1'b0, ~info_c.is_normal})); // 0 as subnorm
+  assign exponent_addend = signed'(exponent_c + $signed({1'b0, ~info_c.is_normal}) // 0 as subnorm
+                                   - signed'(fpnew_pkg::bias(src2_fmt_q))
+                                   + signed'(fpnew_pkg::bias(dst_fmt_q))); // rebias for dst fmt
   // Biased product exponent is the sum of encoded exponents minus the bias.
   assign exponent_product = (info_a.is_zero || info_b.is_zero) // in case the product is zero, set minimum exp.
                             ? 2 - signed'(fpnew_pkg::bias(dst_fmt_q))

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -192,7 +192,7 @@ or set Features.FpFmtMask to support only FP32");
       always_comb begin : prepare_input
         for (int unsigned i = 0; i < NUM_OPERANDS; i++) begin
           if (i == 2) begin
-            local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(dst_fmt_i);
+            local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(op_i == fpnew_pkg::ADDS ? src_fmt_i : dst_fmt_i);
           end else begin
             local_operands[i] = operands_i[i] >> LANE*fpnew_pkg::fp_width(src_fmt_i);
           end


### PR DESCRIPTION
I'd like to apologize, when submitting PR #114 adding the new symmetric add operation `ADDS`, I overlooked three things:
- the new operation of course needs to be added to the case statements that assign default values to the operands based on the operation in both `fpnew_fma.sv` and `fpnew_fma_multi.sv`
- the multi FMA's addend exponent needs to be rebiased for the dst format (so far this was not necessary because the addend was already in dst format - however, for the `ADDS` operation it is not)
- when extracting an FMA lane's local operands the `operands_i[2]` needs to be shifted using the correct format, which for the `ADDS` operation is the src format and not the dst format

This PR fixes these issues. Please excuse my sloppiness :see_no_evil: