### PR TITLE
:adhesive_bandage: Split round mode pipeline signal in verilator

### DIFF
--- a/src/fpnew_divsqrt_th_64_multi.sv
+++ b/src/fpnew_divsqrt_th_64_multi.sv
@@ -89,7 +89,7 @@ module fpnew_divsqrt_th_64_multi #(
 
   // Input pipeline signals, index i holds signal after i register stages
   logic                  [0:NUM_INP_REGS][1:0][WIDTH-1:0]       inp_pipe_operands_q;
-  fpnew_pkg::roundmode_e [0:NUM_INP_REGS]                       inp_pipe_rnd_mode_q;
+  fpnew_pkg::roundmode_e [0:NUM_INP_REGS]                       inp_pipe_rnd_mode_q /*verilator split_var */;
   fpnew_pkg::operation_e [0:NUM_INP_REGS]                       inp_pipe_op_q;
   fpnew_pkg::fp_format_e [0:NUM_INP_REGS]                       inp_pipe_dst_fmt_q;
   TagType                [0:NUM_INP_REGS]                       inp_pipe_tag_q;


### PR DESCRIPTION
For a strange reason Verilator doesn't propagate the round mode input signal into the pipeline register. Using the split_var directive solves the issue. 