### PR TITLE
✨ Add ext reg ena to new TH 64 divsqrt unit

### DIFF
--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -325,7 +325,8 @@ FP16alt, FP8. Please use the PULP DivSqrt unit when in need of div/sqrt operatio
             .aux_o            ( lane_aux[lane]      ),
             .out_valid_o      ( out_valid           ),
             .out_ready_i      ( out_ready           ),
-            .busy_o           ( lane_busy[lane]     )
+            .busy_o           ( lane_busy[lane]     ),
+            .reg_ena_i
           );
         end else begin : gen_pulp_divsqrt
           fpnew_divsqrt_multi #(


### PR DESCRIPTION
This PR adds the external register enable signal to the wrapper of the new TH64 div/sqrt unit, in the same fashion as it has been added to the other opgroups in #89. As with these earlier changes, if the new `reg_ena_i` port is tied to `'0`, then the logic remains semantically equivalent.