### PR TITLE
⚡️ Calculate positive and negative FMA sums in parallel

### DIFF
--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -472,6 +472,14 @@ module fpnew_fma_multi #(
   assign sum_carry = sum_raw[3*PRECISION_BITS+4];
 
   // Complement negative sum (can only happen in subtraction -> overflows for positive results)
+  // Note: Technically the negation of `sum_raw` here is incorrect because it does not consider the
+  // sticky bit (should actually be `~sum_raw + ~sticky_before_add`) but this does not matter
+  // because if the addend is shifted right far enough for `sticky_before_add` to be 1, then
+  // `sum_carry` will always be 1 as well for an effective subtraction (because then at least the
+  // 2p upper bits `of addend_after_shift` will be 0, turning into 1s in `addend_shifted` and since
+  // at least one of the multiplicands needs to be normal for such a large shift to happen there
+  // will be a 1 bit far enough left in the product to propagate a carry into `sum_carry`) and hence
+  // the negation of `sum_raw` is never used if `sticky_before_add` is 1.
   assign sum        = (effective_subtraction && ~sum_carry) ? -sum_raw : sum_raw;
 
   // In case of a mispredicted subtraction result, do a sign flip

--- a/src/fpnew_fma_multi.sv
+++ b/src/fpnew_fma_multi.sv
@@ -462,25 +462,22 @@ module fpnew_fma_multi #(
   // ------
   // Adder
   // ------
-  logic [3*PRECISION_BITS+4:0] sum_raw;   // added one bit for the carry
-  logic                        sum_carry; // observe carry bit from sum for sign fixing
-  logic [3*PRECISION_BITS+3:0] sum;       // discard carry as sum won't overflow
+  logic [3*PRECISION_BITS+4:0] sum_pos, sum_neg; // added one bit for the carry
+  logic                        sum_carry;        // observe carry bit from positive sum for sign fixing
+  logic [3*PRECISION_BITS+3:0] sum;              // discard carry as sum won't overflow
   logic                        final_sign;
 
   //Mantissa adder (ab+c). In normal addition, it cannot overflow.
-  assign sum_raw = product_shifted + addend_shifted + inject_carry_in;
-  assign sum_carry = sum_raw[3*PRECISION_BITS+4];
+  assign sum_pos = product_shifted + addend_shifted + inject_carry_in;
+  assign sum_carry = sum_pos[3*PRECISION_BITS+4];
+
+  // Parallel adder for negative sum (only used for effective subtractions).
+  // Note: inject_carry_in is used to complete the negation of the addend in the positive sum but
+  // for the negative sum the addend is not negated, so no carry needs to be injected.
+  assign sum_neg = addend_after_shift - product_shifted;
 
   // Complement negative sum (can only happen in subtraction -> overflows for positive results)
-  // Note: Technically the negation of `sum_raw` here is incorrect because it does not consider the
-  // sticky bit (should actually be `~sum_raw + ~sticky_before_add`) but this does not matter
-  // because if the addend is shifted right far enough for `sticky_before_add` to be 1, then
-  // `sum_carry` will always be 1 as well for an effective subtraction (because then at least the
-  // 2p upper bits `of addend_after_shift` will be 0, turning into 1s in `addend_shifted` and since
-  // at least one of the multiplicands needs to be normal for such a large shift to happen there
-  // will be a 1 bit far enough left in the product to propagate a carry into `sum_carry`) and hence
-  // the negation of `sum_raw` is never used if `sticky_before_add` is 1.
-  assign sum        = (effective_subtraction && ~sum_carry) ? -sum_raw : sum_raw;
+  assign sum        = (effective_subtraction && ~sum_carry) ? sum_neg : sum_pos;
 
   // In case of a mispredicted subtraction result, do a sign flip
   assign final_sign = (effective_subtraction && (sum_carry == tentative_sign))


### PR DESCRIPTION
The FMA currently calculates the sum of the product and the addend first and, in case certain conditions are met, it then negates it.

https://github.com/openhwgroup/cvfpu/blob/eba1bbebd84121a529a4696c5ce792da3013a8bd/src/fpnew_fma_multi.sv#L474-L475

However, two's complement negation requires another full carry chain over the width of the sum, which means that the FMA currently has two sequential carry chains over the entire `3*PRECISION_BITS+4` bits of the sum (one for the addition and another one for the negation). This leads to long paths and timing issues.

A common way to reduce the length of signal paths in a FP adder is to calculate a positive and a negative sum in parallel and then select the correct result with a mux. The advantage is that the carry chains are no longer sequential but parallel instead. The Wally core uses this technique in its FMA: https://github.com/openhwgroup/cvw/blob/main/src/fpu/fma/fmaadd.sv

This PR modifies the FMA of CVFPU accordingly. We have verified that it is equivalent to the current implementation with Synopsys VC formal's sequential equivalence check (the script to reproduce the check is posted in a comment below).

Initial results from preliminary PD runs in FC suggest that TNS is reduced and timing ameliorated.