### PR TITLE
Replace FMA's LZC with CVW's LZA

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -40,6 +40,7 @@ sources:
   - src/fpnew_divsqrt_th_32.sv
   - src/fpnew_divsqrt_th_64_multi.sv
   - src/fpnew_divsqrt_multi.sv
+  - vendor/cvw/fma/fmalza.sv
   - src/fpnew_fma.sv
   - src/fpnew_fma_multi.sv
   - src/fpnew_noncomp.sv

--- a/vendor/cvw/fma/fmalza.sv
+++ b/vendor/cvw/fma/fmalza.sv
@@ -1,0 +1,68 @@
+///////////////////////////////////////////
+// fmalza.sv
+//
+// Written:  6/23/2021 me@KatherineParry.com, David_Harris@hmc.edu
+// Modified:
+//
+// Purpose: Leading Zero Anticipator
+//
+// Documentation: RISC-V System on Chip Design Chapter 13 (Figure 13.14)
+//    See also [Schmookler & Nowka, Leading zero anticipation and detection, IEEE Sym. Computer Arithmetic, 2001]
+//
+// A component of the CORE-V-WALLY configurable RISC-V project.
+// https://github.com/openhwgroup/cvw
+//
+// Copyright (C) 2021-23 Harvey Mudd College & Oklahoma State University
+//
+// SPDX-License-Identifier: Apache-2.0 WITH SHL-2.1
+//
+// Licensed under the Solderpad Hardware License v 2.1 (the “License”); you may not use this file
+// except in compliance with the License, or, at your option, the Apache License version 2.0. You
+// may obtain a copy of the License at
+//
+// https://solderpad.org/licenses/SHL-2.1/
+//
+// Unless required by applicable law or agreed to in writing, any work distributed under the
+// License is distributed on an “AS IS” BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+// either express or implied. See the License for the specific language governing permissions
+// and limitations under the License.
+////////////////////////////////////////////////////////////////////////////////////////////////
+
+module fmalza #(WIDTH, NF) (
+  input logic [WIDTH-1:0]             A,              // addend
+  input logic [2*NF+1:0]              Pm,             // product
+  input logic                         Cin,            // carry in
+  input logic                         sub,            // subtraction
+  output logic [$clog2(WIDTH+1)-1:0]  SCnt            // normalization shift count for the positive result
+);
+
+  logic [WIDTH:0]                     F;              // most significant bit of F indicates leading digit
+  logic [WIDTH-1:0]                   B;              // zero-extended product with same size as aligned A
+  logic [WIDTH-1:0]                   P, G, K;        // propagate, generate, kill for each column
+  logic [WIDTH-1:0]                   Pp1, Gm1, Km1;  // propagate shifted right by 1, generate/kill shifted left 1
+
+  assign B = {{(NF+2){1'b0}}, Pm, 2'b0};              // Zero extend product
+
+  assign P = A^B;
+  assign G = A&B;
+  assign K = ~A&~B;
+
+  assign Pp1 = {sub, P[WIDTH-1:1]};                   // shift P right by 1 (for P_i+1) , use subtract flag in most significant bit
+  assign Gm1 = {G[WIDTH-2:0], Cin};                   // shift G left by 1 (for G_i-1) and bring in Cin
+  assign Km1 = {K[WIDTH-2:0], ~Cin};                  // shift K left by 1 (for K_i-1) and bring in Cin
+
+  // Apply function to determine Leading pattern
+  //      - note: Schmookler01 uses the numbering system where 0 is the most significant bit
+  assign F[WIDTH]     = ~sub&P[WIDTH-1];
+  assign F[WIDTH-1:0] = (Pp1&(G&~Km1 | K&~Gm1)) | (~Pp1&(K&~Km1 | G&~Gm1));
+
+  lzc #(
+    .WIDTH ( WIDTH+1 ),
+    .MODE  ( 1       ) // MODE = 1 counts leading zeroes
+  ) i_lzc (
+    .in_i    ( F          ),
+    .cnt_o   ( SCnt       ),
+    .empty_o ( /*unused*/ )
+  );
+
+endmodule


### PR DESCRIPTION
# Replace leading zero counter with leading zero anticipator in FMA sum path

## Summary
This PR optimizes the floating-point multiply-add (FMA) unit by replacing the sequential leading zero counter (LZC) in the sum path with a parallel leading zero anticipator (LZA). This change removes normalization from the critical path, significantly improving FMA performance.

## Problem
The previous implementation computed the sum first, then counted leading zeros for normalization:
```
Multiply → Align → Add/Subtract → Count Leading Zeros → Normalize → Result
                                      ↑
                               Critical path bottleneck
```

This sequential approach added unnecessary latency to the FMA operation, as normalization had to wait for the complete sum calculation.

## Solution
Added Schmookler's leading zero anticipation algorithm [IEEEX](https://ieeexplore.ieee.org/document/930098), implemented in the [Walley Core](https://github.com/openhwgroup/cvw/blob/main/src/fpu/fma/fmalza.sv) that predicts the normalization shift count in parallel with the sum computation:

```
Multiply → Align → Add/Subtract ──────────→ Normalize → Result
           ↓                               ↗
           └── Leading Zero Anticipator ──┘
           (in parallel)
```

## Technical Details
The LZA implementation:
- Uses carry-lookahead logic (P/G/K signals) to predict leading zero patterns
- Handles both addition and subtraction operations via the `sub` control signal
- Added logic to detect and handle miss-predictions by one
- Feeds the predicted shift count directly to the normalization stage

## Testing
- Verified with Synopsys VC formal 's sequential equivalence check
- Proven to be equal
```
  Summary Proofs:
   ----------------------------------------------------------------------------------------------------------------------
    VpId |           Name |      Type |         Parent |     #A |     #C |     #S |     #F |     #I |    Status |     %
   ----------------------------------------------------------------------------------------------------------------------
       0 |         seqdef |      root |            nil |     13 |      3 |     13 |      0 |      0 |   success |   100
       0 |      seqdef-rw |        or |         seqdef |      - |      - |      - |      - |      - |         - |     -
       0 |          rw1_1 |       int |      seqdef-rw |      5 |      0 |      5 |      0 |      0 |   success |   100
       0 |       rw1_1-ur |        or |          rw1_1 |      - |      - |      - |      - |      - |         - |     -
       0 |           ur_1 |      leaf |       rw1_1-ur |      4 |      0 |      4 |      0 |      0 |   success |   100
       0 |      rw1_1-dcp | decompose |          rw1_1 |      - |      - |      - |      - |      - |         - |     -
       0 |         idcp_1 |      leaf |      rw1_1-dcp |      4 |      0 |      4 |      0 |      0 |   success |   100
   ----------------------------------------------------------------------------------------------------------------------

```

