### PR TITLE
Fix: Handle underflow properly at subnormal/normal boundary

### DIFF
--- a/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v
+++ b/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v
@@ -404,7 +404,7 @@ assign ex4_rst_inf[63:0]       = (vfdsu_ex4_double) ? ex4_doub_rst_inf[63:0] :
                                   vfdsu_ex4_half    ? ex4_half_rst_inf[63:0] : ex4_bfloat_rst_inf[63:0];
 
       
-assign ex4_cor_uf            = (vfdsu_ex4_uf && !ex4_denorm_potnt_norm || ex4_uf_plus)
+assign ex4_cor_uf            = (vfdsu_ex4_uf || ex4_denorm_potnt_norm || ex4_uf_plus)
                                && vfdsu_ex4_nx;
 assign ex4_cor_nx            =  vfdsu_ex4_nx 
                                 || vfdsu_ex4_of 

--- a/vendor/patches/openc910/0001-Fix-Handle-underflow-properly-at-subnormal-normal-bo.patch
+++ b/vendor/patches/openc910/0001-Fix-Handle-underflow-properly-at-subnormal-normal-bo.patch
@@ -1,0 +1,25 @@
+From 2412caed0dfad31332878410e78754880654c60b Mon Sep 17 00:00:00 2001
+From: Ihsane TAHIR <ihsane.tahir@cea.fr>
+Date: Fri, 29 Aug 2025 13:51:02 +0200
+Subject: [PATCH] Fix: Handle underflow properly at subnormal/normal boundary
+
+---
+ .../openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v b/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v
+index 681b77a..fe56ca0 100644
+--- a/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v
++++ b/vendor/openc910/C910_RTL_FACTORY/gen_rtl/vfdsu/rtl/ct_vfdsu_pack.v
+@@ -404,7 +404,7 @@ assign ex4_rst_inf[63:0]       = (vfdsu_ex4_double) ? ex4_doub_rst_inf[63:0] :
+                                   vfdsu_ex4_half    ? ex4_half_rst_inf[63:0] : ex4_bfloat_rst_inf[63:0];
+ 
+       
+-assign ex4_cor_uf            = (vfdsu_ex4_uf && !ex4_denorm_potnt_norm || ex4_uf_plus)
++assign ex4_cor_uf            = (vfdsu_ex4_uf || ex4_denorm_potnt_norm || ex4_uf_plus)
+                                && vfdsu_ex4_nx;
+ assign ex4_cor_nx            =  vfdsu_ex4_nx 
+                                 || vfdsu_ex4_of 
+-- 
+2.17.2
+


### PR DESCRIPTION
This PR offers a patch for T-Head openc910 DivSqrt unit instantiated in THMULTI.

It fixes the handling of the underflow exception in the case where the result of the division, as though the exponent range were unbounded, lies strictly between  ±b^emin. Even if the rounded result is exactly ±b^emin.

It resolves issue https://github.com/openhwgroup/cvfpu/issues/155
