### PR TITLE
Fix NaN-boxing issue in div-sqrt unit

### DIFF
--- a/src/fpnew_divsqrt_th_64_multi.sv
+++ b/src/fpnew_divsqrt_th_64_multi.sv
@@ -322,7 +322,6 @@ module fpnew_divsqrt_th_64_multi #(
   fpnew_pkg::operation_e divsqrt_op_q;
   logic div_op, sqrt_op;
   logic [WIDTH-1:0] srcf0_q, srcf1_q;
-  logic [63:0] srcf0, srcf1;
   
   // Save operands in regs, C910 saves all the following information in its regs in the next cycle.
   `FFL(rm_q, rnd_mode_q, op_starting, fpnew_pkg::RNE)
@@ -330,60 +329,6 @@ module fpnew_divsqrt_th_64_multi #(
   `FFL(divsqrt_op_q, op_q, op_starting, fpnew_pkg::DIV)
   `FFL(srcf0_q, operands_q[0], op_starting, '0)
   `FFL(srcf1_q, operands_q[1], op_starting, '0)
-
-  // NaN-box inputs with max WIDTH
-  if(WIDTH == 64) begin : gen_fmt_64_bits
-    always_comb begin : NaN_box_inputs
-      if(divsqrt_fmt_q == 4'b1000) begin // 64-bit
-        srcf0[63:0] = srcf0_q[63:0];
-        srcf1[63:0] = srcf1_q[63:0];
-      end else if(divsqrt_fmt_q == 4'b0100) begin // 32-bit
-        srcf0[63:32] = '1;
-        srcf1[63:32] = '1;
-        srcf0[31:0] = srcf0_q[31:0];
-        srcf1[31:0] = srcf1_q[31:0];
-      end else if((divsqrt_fmt_q == 4'b0010) || (divsqrt_fmt_q == 4'b0001)) begin //16-bit
-        srcf0[63:16] = '1;
-        srcf1[63:16] = '1;
-        srcf0[15:0] = srcf0_q[15:0];
-        srcf1[15:0] = srcf1_q[15:0];
-      end else begin // Unsupported
-        srcf0[63:0] = '1;
-        srcf1[63:0] = '1;
-      end
-    end
-  end else if (WIDTH == 32) begin : gen_fmt_32_bits
-    always_comb begin : NaN_box_inputs
-      if(divsqrt_fmt_q == 4'b0100) begin // 32-bit
-        srcf0[63:32] = '1;
-        srcf1[63:32] = '1;
-        srcf0[31:0] = srcf0_q[31:0];
-        srcf1[31:0] = srcf1_q[31:0];
-      end else if((divsqrt_fmt_q == 4'b0010) || (divsqrt_fmt_q == 4'b0001)) begin // 16-bit
-        srcf0[63:16] = '1;
-        srcf1[63:16] = '1;
-        srcf0[15:0] = srcf0_q[15:0];
-        srcf1[15:0] = srcf1_q[15:0];
-      end else begin // Unsupported
-        srcf0[63:0] = '1;
-        srcf1[63:0] = '1;
-      end
-    end
-  end else if (WIDTH == 16) begin : gen_fmt_16_bits
-    always_comb begin : NaN_box_inputs
-      if((divsqrt_fmt_q == 4'b0010) || (divsqrt_fmt_q == 4'b0001)) begin // 16-bit
-        srcf0[63:16] = '1;
-        srcf1[63:16] = '1;
-        srcf0[15:0] = srcf0_q[15:0];
-        srcf1[15:0] = srcf1_q[15:0];
-      end else begin // Unsupported
-        srcf0[63:0] = '1;
-        srcf1[63:0] = '1;
-      end
-    end
-  end else begin
-    $fatal(1, "DivSqrt THMULTI: Unsupported WIDTH (the supported width are 64, 32, 16)");
-  end
 
   assign div_op = (divsqrt_op_q == fpnew_pkg::DIV) ? 1'b1 : 1'b0;
   assign sqrt_op = (divsqrt_op_q != fpnew_pkg::DIV) ? 1'b1 : 1'b0;
@@ -405,8 +350,8 @@ module fpnew_divsqrt_th_64_multi #(
     .dp_vfdsu_ex1_pipex_iid         ( '0                        ), // Don't care, used in C910
     .dp_vfdsu_ex1_pipex_imm0        ( 3'b111                    ), // Round mode, set to 3'b111 to select vfpu_yy_xx_rm signal
     .dp_vfdsu_ex1_pipex_sel         ( op_sel                    ), // 3. Select operands, start operation
-    .dp_vfdsu_ex1_pipex_srcf0       ( srcf0                     ), // Input for operand 0
-    .dp_vfdsu_ex1_pipex_srcf1       ( srcf1                     ), // Input for operand 1
+    .dp_vfdsu_ex1_pipex_srcf0       ( srcf0_q                     ), // Input for operand 0
+    .dp_vfdsu_ex1_pipex_srcf1       ( srcf1_q                     ), // Input for operand 1
     .dp_vfdsu_fdiv_gateclk_issue    ( 1'b1                      ), // Local clock enable (same as above)
     .dp_vfdsu_idu_fdiv_issue        ( op_starting               ), // 1. Issue fdiv (FSM in ctrl)
     .forever_cpuclk                 ( clk_i                     ), // Clock input


### PR DESCRIPTION
## Description
Fixes the NaN-boxing violation in the divsqrt wrapper `fpnew_divsqrt_th_64_multi.sv`. The root cause is the wrapper was unconditionally NaN-boxing input operands before forwarding them to the T-Head C910 div/sqrt unit, regardless of whether the inputs were already NaN-boxed upstream. This caused non-NaN-boxed inputs, which should be treated as canonical NaNs per the RISC-V spec, to have their lower n (<FLEN) bits interpreted directly instead.

## Changes
Remove the unconditional NaN-boxing logic from the wrapper entirely and forward operands as-is, since the T-Head units already implement NaN-boxing detection internally. This approach avoids duplicating responsibility that already exists further down the pipeline, as opposed to the conditional NaN-boxing introduced in PR #158 which fixed the symptom but not the root cause.

Fixes openhwgroup/cva6#3123
Fixes openhwgroup/cva6#3124
Fixes openhwgroup/cva6#3125
Fixes openhwgroup/cva6#2449

## Validation
These changes have been tested by running a non-regression on the updated [cvfpu-uvm](https://github.com/openhwgroup/cvfpu-uvm/issues) environment with nan-boxing configurable, running both DIV and SQRT operations across FP32, FP64 and FP16 formats. 