### PR TITLE
Fix: add missing assignment of `lane_early_out_valid_o`

### DIFF
--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -426,6 +426,7 @@ FP8. Please use the PULP DivSqrt unit when in need of div/sqrt operations on FP8
 
     // Otherwise generate constant sign-extension
     end else begin : inactive_lane
+      assign lane_early_out_valid[lane] = 1'b0; // unused lane
       assign lane_out_valid[lane] = 1'b0; // unused lane
       assign lane_in_ready[lane]  = 1'b0; // unused lane
       assign lane_aux[lane]       = 1'b0; // unused lane


### PR DESCRIPTION
This PR fixes the issue https://github.com/openhwgroup/cvfpu/issues/161 where `early_out_valid_o` can become X during simulation.

In `fpnew_opgroup_multifmt_slice`, the signal `lane_early_out_valid` is not assigned in the `inactive_lane` generate block. As a result,  this signal remains undriven (X).