### PR TITLE
`fpnew_cast_multi`: Fix incorrect NV flag for FP64 to signed INT32 conversion when result rounds to `INT32_MIN`

### DIFF
--- a/src/fpnew_cast_multi.sv
+++ b/src/fpnew_cast_multi.sv
@@ -450,8 +450,7 @@ module fpnew_cast_multi #(
       if ((input_exp_q >= signed'(fpnew_pkg::int_width(int_fmt_q2) - 1 + op_mod_q2))    // Exponent larger than max int range,
           && !(!op_mod_q2                                                               // unless cast to signed int
                && input_sign_q                                                          // and input value is larges negative int value
-               && (input_exp_q == signed'(fpnew_pkg::int_width(int_fmt_q2) - 1))
-               && (input_mant_q == {1'b1, {INT_MAN_WIDTH-1{1'b0}}}))) begin
+               && (input_exp_q == signed'(fpnew_pkg::int_width(int_fmt_q2) - 1)))) begin
         denorm_shamt    = '0; // prevent shifting
         of_before_round = 1'b1;
       // underflow
@@ -634,6 +633,14 @@ module fpnew_cast_multi #(
         if (!rounded_sign && input_exp_q == signed'(INT_WIDTH - 2 + op_mod_q2)) begin
           // Check whether the rounded MSB differs from unrounded MSB
           ifmt_of_after_round[ifmt] = ~rounded_int_res[INT_WIDTH-2+op_mod_q2];
+        end
+        // Negative overflow: value at exp=INT_WIDTH-1 rounded more negative than INT_MIN
+        // This can happen with RDN/RNE when fractional bits cause rounding away from zero.
+        // Detect by checking if the negated magnitude overflowed INT_MIN's bit position.
+        if (!op_mod_q2 && rounded_sign && input_exp_q == signed'(INT_WIDTH - 1)) begin
+            ifmt_of_after_round[ifmt] = ~rounded_uint_res[INT_WIDTH-1];
+            // If bit INT_WIDTH-1 is set in the two's complement negative result, it means
+            // -(magnitude) underflowed past INT_MIN = -2^(INT_WIDTH-1)
         end
       end
     end else begin : inactive_format


### PR DESCRIPTION
## Description
This PR fixes an incorrect **NV** flag being raised when converting a negative FP64 value to signed INT32, where the result rounds exactly to `-2^(N-1)` (i.e. `INT32_MIN`, when `N=32`). The value is representable in INT32 and should only raise **NX** (inexact), not **NV** (invalid) flag.

Fixes https://github.com/openhwgroup/cvfpu/issues/154. Related to #83, fixed in #101.

The existing `of_before_round` check correctly carves out the case where the input float is exactly `-2^(N-1)`:
https://github.com/openhwgroup/cvfpu/blob/a74d99a32bd11ce0b05a82b0d6d26f98df3bba65/src/fpnew_cast_multi.sv#L450-L454

However this carve-out requires the mantissa to be **exactly** `1.0` with no fractional bits. It does not account for the case where a value like `-2^31 - |epsilon|` has fractional bits that round up to exactly `-2^31` after rounding. In that case:

- `of_before_round` fires because `input_exp_q == INT_WIDTH - 1` and the mantissa is not exactly `1.0`
- The result is incorrectly routed to the special case path, saturating to `INT_MIN` with **NV=1**
- The correct behavior is to return `INT_MIN` with **NX=1** since the rounded result is representable

Additionally, `of_after_round` only checked positive boundary overflow:
https://github.com/openhwgroup/cvfpu/blob/a74d99a32bd11ce0b05a82b0d6d26f98df3bba65/src/fpnew_cast_multi.sv#L633-L634

Leaving the symmetric negative boundary case, where rounding pushes a value past `INT_MIN`, undetected.


## Changes
The following changes were made to **fpnew_cast_multi.sv** to address this issue

### 1. `of_before_round`: Remove mantissa exact-match requirement

The existing carve-out is extended to suppress `of_before_round` for **any** negative value at `input_exp_q == INT_WIDTH - 1`, regardless of fractional bits. The responsibility for detecting true negative overflow at this exponent is delegated entirely to `of_after_round`, which has access to the post-rounding result.

This allows values like `-2^31 - |epsilon|` to proceed through the normal rounding path instead of being prematurely saturated.

### 2. `of_after_round`: Add negative boundary overflow detection

A new condition detects the case where rounding pushes a negative value past `INT_MIN`. This is the symmetric counterpart to the existing positive overflow check.

## Validation
These changes were validated by running a non-regression in the [cvfpu-uvm](https://github.com/openhwgroup/cvfpu-uvm/) verification environment, running F2I operations accross FP32 and FP64 formats and signed/unsigned INT32 and INT64 formats and all supported rounding modes.