### PR TITLE
`fpu_cast_multi`: Fix erroneous flag generation for negative FP to unsigned INT conversion due to wrap-around

### DIFF
--- a/src/fpnew_cast_multi.sv
+++ b/src/fpnew_cast_multi.sv
@@ -619,7 +619,7 @@ module fpnew_cast_multi #(
   end
   
   assign rounded_int_res = ifmt_rounded_signed_res[int_fmt_q2];
-  assign rounded_int_res_zero = (rounded_int_res == '0);
+  assign rounded_int_res_zero = (rounded_int_res == '0) && (pre_round_abs == '0);
 
   // Detect integer overflows after rounding (only positives)
   for (genvar ifmt = 0; ifmt < int'(NUM_INT_FORMATS); ifmt++) begin : gen_int_overflow


### PR DESCRIPTION
## Description
This PR fixes https://github.com/openhwgroup/cvfpu/issues/163 where converting large negative floating point inputs to unsigned integers raises the `NX` flag instead of the expected `NV` flag. The root cause is explained in details in the [issue](https://github.com/openhwgroup/cvfpu/issues/163).

## Changes
**`fpnew_cast_multi.svh`**

Update zero detection logic to differentiate bewteen a true zero and an overflown rounded value.

## Validation
These changes were validated by running a non-regression using [cvfpu-uvm](https://github.com/openhwgroup/cvfpu-uvm) testing `F2I` operations from `FP64` and `FP32` floating point formats to unsigned/signed 32/64 integers across all rounding modes.
