### PR TITLE
`fpnew_cast_multi`: Fix underflow detection logic at subnormal-nomal boundary

### DIFF
--- a/src/fpnew_cast_multi.sv
+++ b/src/fpnew_cast_multi.sv
@@ -583,7 +583,9 @@ module fpnew_cast_multi #(
     if (FpFmtConfig[fmt]) begin : active_format
       always_comb begin : post_process
         // detect of / uf
-        fmt_uf_after_round[fmt] = rounded_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == '0; // denormal
+        fmt_uf_after_round[fmt] = (rounded_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == '0) // denormal
+            || ((pre_round_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == '0) && (rounded_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == 1) &&
+               ((round_sticky_bits != 2'b11) || (!destination_mant[NUM_FP_STICKY-1] && ((rnd_mode_q == fpnew_pkg::RNE) || (rnd_mode_q == fpnew_pkg::RMM)))));
         fmt_of_after_round[fmt] = rounded_abs[EXP_BITS+MAN_BITS-1:MAN_BITS] == '1; // inf exp.
 
         // Assemble regular result, nan box short ones. Int zeroes need to be detected`


### PR DESCRIPTION
## Description
This PR fixes issue #165 which is a compliance bug in the `fpnew_cast_multi` unit regarding the detection of "tininess" to generate the underflow exception. Based on the RISC-V specifications, tininess must be detected after rounding. The casting unit's previous underflow logic was overly simplistic; it only checked if the rounded result is subnormal, but did not handle properly tininess detection in the subnormal-normal boundary.

## Changes
**`fpnew_multi_cast.svh`**
Adapt and integrate the tininess detection logic already implemented in the fpnew_fma_multi.sv unit, which properly evaluates if the result that rounds up to a normal number should still be flagged as tiny.

## Validation
Validated these changes by running a non-regression using [cvfpu-uvm](https://github.com/openhwgroup/cvfpu-uvm) verification environment, with a focus on `F2F` operations with results falling in the subnormal-normal boundary.