### PR TITLE
`fpnew_divsqrt_th_64_multi` : Fix width mismatch on `ct_vfdsu_top` ports

### DIFF
--- a/src/fpnew_divsqrt_th_64_multi.sv
+++ b/src/fpnew_divsqrt_th_64_multi.sv
@@ -350,8 +350,8 @@ module fpnew_divsqrt_th_64_multi #(
     .dp_vfdsu_ex1_pipex_iid         ( '0                        ), // Don't care, used in C910
     .dp_vfdsu_ex1_pipex_imm0        ( 3'b111                    ), // Round mode, set to 3'b111 to select vfpu_yy_xx_rm signal
     .dp_vfdsu_ex1_pipex_sel         ( op_sel                    ), // 3. Select operands, start operation
-    .dp_vfdsu_ex1_pipex_srcf0       ( srcf0_q                     ), // Input for operand 0
-    .dp_vfdsu_ex1_pipex_srcf1       ( srcf1_q                     ), // Input for operand 1
+    .dp_vfdsu_ex1_pipex_srcf0       ( {{(64-WIDTH){1'b0}}, srcf0_q} ), // Input for operand 0
+    .dp_vfdsu_ex1_pipex_srcf1       ( {{(64-WIDTH){1'b0}}, srcf1_q} ), // Input for operand 1
     .dp_vfdsu_fdiv_gateclk_issue    ( 1'b1                      ), // Local clock enable (same as above)
     .dp_vfdsu_idu_fdiv_issue        ( op_starting               ), // 1. Issue fdiv (FSM in ctrl)
     .forever_cpuclk                 ( clk_i                     ), // Clock input


### PR DESCRIPTION
## Description
This PR fixes issue #171.

`ct_vfdsu_top`'s operand ports are hardcoded to 64 bits, but the wrapper was connecting them directly to WIDTH-bit signals.

## Changes
`fpnew_divsqrt_th_64_multi.sv`: Explicitly zero-extend the operand signals to 64 bits before connecting them to `ct_vfdsu_top`.