### PR TITLE
`fpnew_divsqrt_th_64_multi`: Clear `func_sel`/`op_sel`/`unit_done_q` registers on flush to prevent simulation hang 

### DIFF
--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -214,7 +214,7 @@ module fpnew_divsqrt_multi #(
   // As soon as all the lanes are over, we can clear this FF and start with a new operation
   logic unit_done_clear;
   `FFLARNC(unit_done_q, unit_done, unit_done, unit_done_clear, 1'b0, clk_i, rst_ni)
-  assign unit_done_clear = simd_synch_done | reg_ena_i[NUM_INP_REGS-1];
+  assign unit_done_clear = flush_i | simd_synch_done | reg_ena_i[NUM_INP_REGS-1];
   // Tell the other units that this unit has finished now or in the past
   assign divsqrt_done_o = (unit_done_q | unit_done) & result_vec_op_q;
 

--- a/src/fpnew_divsqrt_th_64_multi.sv
+++ b/src/fpnew_divsqrt_th_64_multi.sv
@@ -234,7 +234,7 @@ module fpnew_divsqrt_th_64_multi #(
   // As soon as all the lanes are over, we can clear this FF and start with a new operation
   logic unit_done_clear;
   `FFLARNC(unit_done_q, unit_done, unit_done, unit_done_clear, 1'b0, clk_i, rst_ni);
-  assign unit_done_clear = simd_synch_done | last_inp_reg_ena;
+  assign unit_done_clear = simd_synch_done | last_inp_reg_ena | flush_i;
   // Tell the other units that this unit has finished now or in the past
   assign divsqrt_done_o = (unit_done_q | unit_done) & result_vec_op_q;
 
@@ -335,11 +335,11 @@ module fpnew_divsqrt_th_64_multi #(
   
   // Select func 1 cycle after div issue
   logic func_sel;
-  `FFLARNC(func_sel, 1'b1, op_starting, func_sel, 1'b0, clk_i, rst_ni)
+  `FFLARNC(func_sel, 1'b1, op_starting, func_sel | flush_i, 1'b0, clk_i, rst_ni)
 
   // Select operands 2 cycles after div issue
   logic op_sel;
-  `FFLARNC(op_sel, 1'b1, func_sel, op_sel, 1'b0, clk_i, rst_ni)
+  `FFLARNC(op_sel, 1'b1, func_sel, op_sel | flush_i, 1'b0, clk_i, rst_ni)
 
   ct_vfdsu_top i_ct_vfdsu_top (
     .cp0_vfpu_icg_en                ( 1'b0                      ), // Internal clock gating, (module enable) doesn't matter when the clk_gate module is redundant anyway


### PR DESCRIPTION
## Description
This PR fixes #173, a simulation hang observed when a flush is asserted while a division request is in-fight.

`fpnew_divsqrt_th_64_multi.sv` the wrapper of the C910 T-Head div/sqrt unit uses two pulses to launch execution of the operation: `func_sel` and `op_sel`. Neither is cleared by `flush_i` signal. If a flush occurs between request acceptance (`op_starting`) and the actual launch of the operation inside `ct_vfdsu_top`, these pulses still fire and the request is never dropped. This leaves the unit in hang state where it does not accept any request after the flush is processed.

Separately, `unit_done_q `, the register that latches `unit_done` while waiting for the other SIMD lanes to finish, is also missing `flush_i` in its clear condition.
**Edit**: This PR fixes #176.

## Changes
**`fpnew_divsqrt_th_64_multi.sv`**
Add `flush_i` to the clear logic of `func_sel`, `op_sel` and `unit_done_q`.

## Validation
Verified against `fpu_op_group_test.svh` and `seed=1760627103`. Re-ran full regression -> PASS. 