### PR TITLE
flush the stale done flag in divsqrt module

### DIFF
--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -214,7 +214,7 @@ module fpnew_divsqrt_multi #(
   // As soon as all the lanes are over, we can clear this FF and start with a new operation
   logic unit_done_clear;
   `FFLARNC(unit_done_q, unit_done, unit_done, unit_done_clear, 1'b0, clk_i, rst_ni)
-  assign unit_done_clear = simd_synch_done | reg_ena_i[NUM_INP_REGS-1];
+  assign unit_done_clear = flush_i | simd_synch_done | reg_ena_i[NUM_INP_REGS-1];
   // Tell the other units that this unit has finished now or in the past
   assign divsqrt_done_o = (unit_done_q | unit_done) & result_vec_op_q;
 

--- a/src/fpnew_divsqrt_th_64_multi.sv
+++ b/src/fpnew_divsqrt_th_64_multi.sv
@@ -234,7 +234,7 @@ module fpnew_divsqrt_th_64_multi #(
   // As soon as all the lanes are over, we can clear this FF and start with a new operation
   logic unit_done_clear;
   `FFLARNC(unit_done_q, unit_done, unit_done, unit_done_clear, 1'b0, clk_i, rst_ni);
-  assign unit_done_clear = simd_synch_done | last_inp_reg_ena;
+  assign unit_done_clear = flush_i | simd_synch_done | last_inp_reg_ena;
   // Tell the other units that this unit has finished now or in the past
   assign divsqrt_done_o = (unit_done_q | unit_done) & result_vec_op_q;
 


### PR DESCRIPTION
This PR is to fix issue #176 . We add the `flush_i` to set `unit_done_clear` signal to ensure that the stale state in Divsqrt module cannot persists across exception and domain transitions.