### PR TITLE
fpnew: Fix PULP DivSqrt RDN/RUP rounding, document unsupported RMM

### DIFF
--- a/src/fpnew_divsqrt_multi.sv
+++ b/src/fpnew_divsqrt_multi.sv
@@ -295,6 +295,21 @@ module fpnew_divsqrt_multi #(
   fpnew_pkg::status_t unit_status, held_status_q;
   logic               hold_en;
 
+  // fpnew (RISC-V) rounding-mode encoding differs from the MVP unit's C_RM_* encoding.
+  // RNE/RTZ coincide; RDN/RUP are swapped. RMM/ROD/DYN have no equivalent in the MVP
+  // unit (see the DivSqrtSel=PULP $warning in fpnew_opgroup_multifmt_slice.sv) and are
+  // passed through unmapped, where they fall into div_sqrt_top_mvp's own default case.
+  logic [2:0] divsqrt_rm;
+  always_comb begin
+    case (rnd_mode_q)
+      fpnew_pkg::RNE: divsqrt_rm = 3'd0; // MVP C_RM_NEAREST
+      fpnew_pkg::RTZ: divsqrt_rm = 3'd1; // MVP C_RM_TRUNC
+      fpnew_pkg::RDN: divsqrt_rm = 3'd3; // MVP C_RM_MINUSINF
+      fpnew_pkg::RUP: divsqrt_rm = 3'd2; // MVP C_RM_PLUSINF
+      default:        divsqrt_rm = rnd_mode_q; // RMM/ROD/DYN: not supported by div_sqrt_top_mvp
+    endcase
+  end
+
   div_sqrt_top_mvp i_divsqrt_lei (
    .Clk_CI           ( clk_i                               ),
    .Rst_RBI          ( rst_ni                              ),
@@ -302,7 +317,7 @@ module fpnew_divsqrt_multi #(
    .Sqrt_start_SI    ( sqrt_valid                          ),
    .Operand_a_DI     ( divsqrt_operands[0]                 ),
    .Operand_b_DI     ( divsqrt_operands[1]                 ),
-   .RM_SI            ( rnd_mode_q                          ),
+   .RM_SI            ( divsqrt_rm                          ),
    .Precision_ctl_SI ( '0                                  ),
    .Format_sel_SI    ( divsqrt_fmt                         ),
    .Kill_SI          ( flush_i | reg_ena_i[NUM_INP_REGS-1] ),

--- a/src/fpnew_opgroup_multifmt_slice.sv
+++ b/src/fpnew_opgroup_multifmt_slice.sv
@@ -75,6 +75,10 @@ Set DivSqrtSel = THMULTI or DivSqrtSel = PULP to use a multi-format divider");
     end else if ((DivSqrtSel == fpnew_pkg::THMULTI) && (FpFmtConfig[3] == 1'b1)) begin
       $warning("The DivSqrt unit of C910 (instantiated by DivSqrtSel = THMULTI) does not support \
 FP8. Please use the PULP DivSqrt unit when in need of div/sqrt operations on FP8.");
+    end else if (DivSqrtSel == fpnew_pkg::PULP) begin
+      $warning("The DivSqrt unit instantiated by DivSqrtSel = PULP (div_sqrt_top_mvp) has no \
+native RMM (round to nearest, ties to max magnitude) rounding mode. It falls back to \
+round-to-nearest-ties-to-even, which only differs from RMM on an exact tie.");
     end
   end
 


### PR DESCRIPTION
DivSqrtSel=PULP forwarded RISC-V rounding-mode encoding directly into div_sqrt_top_mvp's RM_SI, but the two encodings disagree for RDN(2)/RUP(3), causing results to round in the wrong direction. Add the missing translation in fpnew_divsqrt_multi.sv.

RMM has no equivalent in div_sqrt_top_mvp at all (only ties-to-even is implemented) and can't be fixed by translation alone; add a $warning in fpnew_opgroup_multifmt_slice.sv documenting this, matching the existing FP8/THMULTI notice pattern.

Partially fixes #178 (RDN/RUP); RMM is a separate, deeper issue (missing hardware support in div_sqrt_top_mvp itself) and is intentionally left unaddressed here.